### PR TITLE
Add hw reset support, PWM BL brightness control

### DIFF
--- a/include/mgos_ili9341.h
+++ b/include/mgos_ili9341.h
@@ -41,10 +41,6 @@
 #define ILI9341_GREENYELLOW 0xAFE5      /* 173, 255,  47 */
 #define ILI9341_PINK        0xF81F
 
-#ifndef SPI_DEFAULT_FREQ
-#define SPI_DEFAULT_FREQ         20000000
-#endif // SPI_DEFAULT_FREQ
-
 #define swap(a, b) { int16_t t = a; a = b; b = t; }
 
 enum mgos_ili9341_rotation_t {
@@ -93,6 +89,5 @@ uint16_t mgos_ili9341_getStringHeight(char *string);
 
 // Images
 void mgos_ili9341_drawDIF(uint16_t x0, uint16_t y0, char *fn);
-
 
 #endif // __MGOS_ILI9341_H

--- a/include/mgos_ili9341_hal.h
+++ b/include/mgos_ili9341_hal.h
@@ -91,6 +91,8 @@
 #define ILI9341_PRC           0xF7
 #define ILI9341_3GAMMA_EN     0xF2
 
+#define ILI9341_INVALID_CMD   0xFF
+
 #define MADCTL_MY             0x80
 #define MADCTL_MX             0x40
 #define MADCTL_MV             0x20
@@ -98,39 +100,5 @@
 #define MADCTL_MH             0x04
 
 #define ILI9341_DELAY   0x80
-
-static const uint8_t ILI9341_init[] = {
-  24,                                                                // 24 commands in list
-  ILI9341_SWRESET, ILI9341_DELAY,                                    //  1: Software reset, no args, w/delay
-  250,                                                               //     200 ms delay
-  ILI9341_POWERA, 5, 0x39, 0x2C, 0x00, 0x34, 0x02,
-  ILI9341_POWERB, 3, 0x00, 0XC1, 0X30,
-  0xEF, 3, 0x03, 0x80, 0x02,
-  ILI9341_DTCA, 3, 0x85, 0x00, 0x78,
-  ILI9341_DTCB, 2, 0x00, 0x00,
-  ILI9341_POWER_SEQ, 4, 0x64, 0x03, 0X12, 0X81,
-  ILI9341_PRC, 1, 0x20,
-  ILI9341_PWCTR1, 1, 0x23,                                           // Power control VRH[5:0]
-  ILI9341_PWCTR2, 1, 0x10,                                           // Power control SAP[2:0];BT[3:0]
-  ILI9341_VMCTR1, 2, 0x3e, 0x28,                                     // VCM control
-  ILI9341_VMCTR2, 1, 0x86,                                           // VCM control2
-  ILI9341_MADCTL, 1,                                                 // Memory Access Control (orientation)
-  (MADCTL_MX | ILI9341_RGB_BGR),
-  // *** INTERFACE PIXEL FORMAT: 0x66 -> 18 bit; 0x55 -> 16 bit
-  ILI9341_PIXFMT, 1, 0x55,
-  ILI9341_INVOFF, 0,
-  ILI9341_FRMCTR1, 2, 0x00, 0x18,
-  ILI9341_DFUNCTR, 4, 0x08, 0x82, 0x27, 0x00,                        // Display Function Control
-  ILI9341_PTLAR, 4, 0x00, 0x00, 0x01, 0x3F,
-  ILI9341_3GAMMA_EN, 1, 0x00,                                        // 3Gamma Function: Disable (0x02), Enable (0x03)
-  ILI9341_GAMMASET, 1, 0x01,                                         // Gamma curve selected (0x01, 0x02, 0x04, 0x08)
-  ILI9341_GMCTRP1, 15,                                               // Positive Gamma Correction
-  0x0F, 0x31, 0x2B, 0x0C, 0x0E, 0x08, 0x4E, 0xF1, 0x37, 0x07, 0x10, 0x03, 0x0E, 0x09, 0x00,
-  ILI9341_GMCTRN1, 15,                                               // Negative Gamma Correction
-  0x00, 0x0E, 0x14, 0x03, 0x11, 0x07, 0x31, 0xC1, 0x48, 0x08, 0x0F, 0x0C, 0x31, 0x36, 0x0F,
-  ILI9341_SLPOUT, ILI9341_DELAY,                                     // Sleep out
-  200,                                                               // 120 ms delay
-  ILI9341_DISPON, ILI9341_DELAY, 200,
-};
 
 #endif // __MGOS_ILI9341_HAL_H

--- a/mos.yml
+++ b/mos.yml
@@ -15,7 +15,9 @@ includes:
 config_schema:
   - ["ili9341", "o", {title: "ILI9341 settings"}]
   - ["ili9341.cs_index", "i", 0, {title: "spi.cs*_gpio index, 0, 1 or 2"}]
+  - ["ili9341.spi_freq", "i", 20000000, {title: "SPI frequency"}]
   - ["ili9341.dc_pin", "i", 33, {title: "TFT DC pin"}]
+  - ["ili9341.rst_pin", "i", -1, {title: "RST pin. If set, will be used to reinit the display."}]
 
 libs:
   - origin: https://github.com/mongoose-os-libs/spi


### PR DESCRIPTION
 * Support hardware reset pin and use it during init.
 * Add `mgos_ili9341_set_backlight()` which takes fractional brightness value, from 0 to 1.

 One could argue that the two above could be done outside of the library, which is true, but i think they are common enough to justify being added to the library.

 * Tweak init sequence somewhat to reduce init delay.
   * Datasheet calls for a 5 ms delay after reset before register writes and then 120 ms before exiting sleep.
 * Make SPI frequency a parameter
   * My unit works fine with 40 MHz. Keep the 20 MHz default though.