### PR TITLE
Added mJS API

### DIFF
--- a/mjs_fs/api_ili9341_spi.js
+++ b/mjs_fs/api_ili9341_spi.js
@@ -1,0 +1,72 @@
+let ILI9341 = {
+    // Constants
+    // Color definitions for RGB in 565-format
+    BLACK: 0x0000, /*   0,   0,   0 */
+    NAVY: 0x000F, /*   0,   0, 128 */
+    DARKGREEN: 0x03E0, /*   0, 128,   0 */
+    DARKCYAN: 0x03EF, /*   0, 128, 128 */
+    MAROON: 0x7800, /* 128,   0,   0 */
+    PURPLE: 0x780F, /* 128,   0, 128 */
+    OLIVE: 0x7BE0, /* 128, 128,   0 */
+    LIGHTGREY: 0xC618, /* 192, 192, 192 */
+    DARKGREY: 0x7BEF, /* 128, 128, 128 */
+    BLUE: 0x001F, /*   0,   0, 255 */
+    GREEN: 0x07E0, /*   0, 255,   0 */
+    CYAN: 0x07FF, /*   0, 255, 255 */
+    RED: 0xF800, /* 255,   0,   0 */
+    MAGENTA: 0xF81F, /* 255,   0, 255 */
+    YELLOW: 0xFFE0, /* 255, 255,   0 */
+    WHITE: 0xFFFF, /* 255, 255, 255 */
+    ORANGE: 0xFD20, /* 255, 165,   0 */
+    GREENYELLOW: 0xAFE5, /* 173, 255,  47 */
+    PINK: 0xF81F,
+
+    //enum mgos_ili9341_rotation_t
+    PORTRAIT: 0,
+    LANDSCAPE: 1,
+    PORTRAIT_FLIP: 2,
+    LANDSCAPE_FLIP: 3,
+
+    // ffi functions
+    // Externally callable functions:
+    set_window: ffi('void mgos_ili9341_set_window(int, int, int, int)'),
+    set_fgcolor: ffi('void mgos_ili9341_set_fgcolor(int, int, int)'),
+    set_bgcolor: ffi('void mgos_ili9341_set_bgcolor(int, int, int)'),
+    color565: ffi('int mgos_ili9341_color565(int, int, int)'),
+    set_fgcolor565: ffi('void mgos_ili9341_set_fgcolor565(int )'),
+    set_bgcolor565: ffi('void mgos_ili9341_set_bgcolor565(int)'),
+    set_dimensions: ffi('void mgos_ili9341_set_dimensions(int, int)'),
+    // argument is enum mgos_ili9341_rotation_t
+    set_rotation: ffi('void mgos_ili9341_set_rotation(int)'),
+    set_inverted: ffi('void mgos_ili9341_set_inverted(bool)'),
+    get_screenWidth: ffi('int mgos_ili9341_get_screenWidth()'),
+    get_screenHeight: ffi('int mgos_ili9341_get_screenHeight()'),
+
+    fillScreen: ffi('void mgos_ili9341_fillScreen()'),
+
+    // Geometric shapes:
+    drawPixel: ffi('void mgos_ili9341_drawPixel(int, int)'),
+    drawLine: ffi('void mgos_ili9341_drawLine(int, int, int, int)'),
+
+    drawRect: ffi('void mgos_ili9341_drawRect(int, int, int, int)'),
+    fillRect: ffi('void mgos_ili9341_fillRect(int, int, int, int)'),
+
+    drawRoundRect: ffi('void mgos_ili9341_drawRoundRect(int, int, int, int, int)'),
+    fillRoundRect: ffi('void mgos_ili9341_fillRoundRect(int, int, int, int, int)'),
+
+    drawCircle: ffi('void mgos_ili9341_drawCircle(int, int, int)'),
+    fillCircle: ffi('void mgos_ili9341_fillCircle(int, int, int)'),
+
+    drawTriangle: ffi('void mgos_ili9341_drawTriangle(int, int, int, int, int, int)'),
+    fillTriangle: ffi('void mgos_ili9341_fillTriangle(int, int, int, int, int, int)'),
+
+    // Fonts and Printing:
+    // argument is GFXfont*, need to find a way to get it
+    set_font: ffi('bool mgos_ili9341_set_font(void*)'),
+    print: ffi('void mgos_ili9341_print(int, int, char *s)'),
+    getStringWidth: ffi('int mgos_ili9341_getStringWidth(char*)'),
+    getStringHeight: ffi('int mgos_ili9341_getStringHeight(char*)'),
+
+    // Images
+    drawDIF: ffi('void mgos_ili9341_drawDIF(int, int, char*)')
+};


### PR DESCRIPTION
Client application will need to create fonts in C code and pass them to mJS:
src/font.c
```
#include "mgos_ili9341.h"
#include "fonts/FreeSerifBold9pt7b.h"

GFXfont* get_font() {
  return &FreeSerifBold9pt7b;
}
```
fs/init.js
```
load('api_ili9341_spi.js')
let get_font=ffi('void* get_font()');

ILI9341.set_fgcolor(0xff, 0, 0);    // red
ILI9341.set_window(20, 30, 119, 59);      // 100x30 pixels
ILI9341.drawRoundRect(0, 0, 100, 30, 8);  // Draw a rounded rectangle
ILI9341.set_fgcolor(0, 0xff, 0);          // Green

let font=get_font();
ILI9341.set_font(font);
ILI9341.print(5, 5, "Hello World");
```
