### PR TITLE
Corrected the test of the return value of "open"

### DIFF
--- a/src/mgos_ili9341.c
+++ b/src/mgos_ili9341.c
@@ -525,8 +525,9 @@ void mgos_ili9341_drawDIF(uint16_t x0, uint16_t y0, char *fn) {
   int       fd;
 
   fd = open(fn, O_RDONLY);
-  if (!fd) {
-    LOG(LL_ERROR, ("%s: Could not opens", fn));
+   // has to be tested not only for NULL
+  if (fd < 0) {
+    LOG(LL_ERROR, ("%s: Could not open", fn));
     goto exit;
   }
   if (16 != read(fd, dif_hdr, 16)) {


### PR DESCRIPTION
In the function `mgos_ili9341_drawDIF`was a wrong test against !NULL when opening a file with `open`. The return value of an error is normally < 0 in this case, so the test against !NULL will not fail and it would be assumed, the file has been successfully opened. This will cause strange errors afterwards.