### PR TITLE
Fix formatting errors for ESP8266 in mos 2.19

### DIFF
--- a/src/mgos_ili9341.c
+++ b/src/mgos_ili9341.c
@@ -169,7 +169,7 @@ static void ili9341_send_pixels(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t 
   }
 
   if (buflen != winsize * 2) {
-    LOG(LL_ERROR, ("Want buflen(%d), to be twice the window size(%d)", buflen, winsize));
+    LOG(LL_ERROR, ("Want buflen(%d), to be twice the window size(%d)", (int)buflen, winsize));
     return;
   }
 
@@ -540,7 +540,7 @@ void mgos_ili9341_drawDIF(uint16_t x0, uint16_t y0, char *fn) {
   }
   w = dif_hdr[7] + (dif_hdr[6] << 8) + (dif_hdr[5] << 16) + (dif_hdr[4] << 24);
   h = dif_hdr[11] + (dif_hdr[10] << 8) + (dif_hdr[9] << 16) + (dif_hdr[8] << 24);
-  LOG(LL_DEBUG, ("%s: width=%d height=%d", fn, w, h));
+  LOG(LL_DEBUG, ("%s: width=%d height=%d", fn, (int)w, (int)h));
   pixelline = calloc(w, sizeof(uint16_t));
 
   for (uint16_t yy = 0; yy < h; yy++) {


### PR DESCRIPTION
Fix formatting errors:
```
ili9341-spi/src/mgos_ili9341.c:172:20: error: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
  172 |     LOG(LL_ERROR, ("Want buflen(%d), to be twice the window size(%d)", buflen, winsize));
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~
      |                                                                        |
      |                                                                        uint32_t {aka long unsigned int}
ili9341-spi/src/mgos_ili9341.c:543:18: error: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
  543 |   LOG(LL_DEBUG, ("%s: width=%d height=%d", fn, w, h));
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~      ~
      |                                                |
      |                                                uint32_t {aka long unsigned int}
ili9341-spi/src/mgos_ili9341.c:543:18: error: format '%d' expects argument of type 'int', but argument 4 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
  543 |   LOG(LL_DEBUG, ("%s: width=%d height=%d", fn, w, h));
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~         ~
      |                                                   |
      |                                                   uint32_t {aka long unsigned int}
```